### PR TITLE
FIXED: clpq was not working with expressions containing floats, since…

### DIFF
--- a/clpq/nf_q.pl
+++ b/clpq/nf_q.pl
@@ -582,7 +582,6 @@ nf(Term,_) :-
 % If N is a number, N is normalized
 
 nf_number(N,Res) :-
-	rational(N),
 	Rat is rationalize(N),
 	(   Rat =:= 0
 	->  Res = []
@@ -968,8 +967,11 @@ repair_p(Term,P,[],L0,L1) :-
 % digested -> cuts after repair of args!
 %
 repair_p_one(Term,TermN) :-
-	nf_number(Term,TermN),	% freq. shortcut for nf/2 case below
-	!.
+	(   number(Term)
+	;   rational(Term)
+	),
+	!,
+        nf_number(Term,TermN).	% freq. shortcut for nf/2 case below
 repair_p_one(A1/A2,TermN) :-
 	repair(A1,A1n),
 	repair(A2,A2n),


### PR DESCRIPTION
Hi Jan,
I send you a patch a couple of weeks ago, may be the mail was filtered, so better I create this pull request.
I was playing around and I found this problem with CLPQ: it was not working with expressions containing floats. It turns out that nf_number/2 was failing for numbers.
Best Regards,

Edison
