### PR TITLE
Fixed a bug

### DIFF
--- a/clpq/bb_q.pl
+++ b/clpq/bb_q.pl
@@ -82,13 +82,12 @@ bb_inf(Is,Term,Inf,Vertex) :-
 % all variables in <Is> are to be integers.
 
 bb_inf_internal(Is,Lin,_,_) :-
-	bb_intern(Is,IsNf),
 	nb_delete(prov_opt),
 	repair(Lin,LinR),	% bb_narrow ...
 	deref(LinR,Lind),
 	var_with_def_assign(Dep,Lind),
 	determine_active_dec(Lind),
-	bb_loop(Dep,IsNf),
+	bb_loop(Dep,Is),
 	fail.
 bb_inf_internal(_,_,Inf,Vertex) :-
 	nb_current(prov_opt,InfVal-Vertex),

--- a/clpq/bb_q.pl
+++ b/clpq/bb_q.pl
@@ -82,12 +82,13 @@ bb_inf(Is,Term,Inf,Vertex) :-
 % all variables in <Is> are to be integers.
 
 bb_inf_internal(Is,Lin,_,_) :-
+	bb_intern(Is,IsNf),
 	nb_delete(prov_opt),
 	repair(Lin,LinR),	% bb_narrow ...
 	deref(LinR,Lind),
 	var_with_def_assign(Dep,Lind),
 	determine_active_dec(Lind),
-	bb_loop(Dep,Is),
+	bb_loop(Dep,IsNf),
 	fail.
 bb_inf_internal(_,_,Inf,Vertex) :-
 	nb_current(prov_opt,InfVal-Vertex),

--- a/clpq/ineq_q.pl
+++ b/clpq/ineq_q.pl
@@ -1086,7 +1086,7 @@ uil(t_Lu(L,U),X,Lin,Bound,Sold) :-
 		    ub(ClassX,OrdX,Vub-Vb-Ub),
 		    Bound >= Ub + L
 		->  get_attr(X,itf,Att2), % changed?
-		    setarg(2,Att2,t_Lu(Bound,U)),
+		    setarg(2,Att2,type(t_Lu(Bound,U))),
 		    setarg(3,Att2,strictness(Strict)),
 		    pivot_a(Vub,X,Vb,t_lu(Bound,U)),
 		    reconsider(X)


### PR DESCRIPTION
This pull request will fix the bugs in 
https://github.com/SWI-Prolog/packages-clpqr/issues/4 
https://github.com/SWI-Prolog/issues/issues/93
https://github.com/SWI-Prolog/issues/issues/63

The problem is that the second argument of the attribute is expected to be of the form type(t_..) but
in a single line of code someone forgot to type "type("  and to close the parenthesis as well, obviously.
This caused, in https://github.com/SWI-Prolog/issues/issues/63, pivot_a to fail when reading the second argument.