### PR TITLE
clpqr/highlight.pl: Don't wrap constraint goal class in 'goal/1'

### DIFF
--- a/clpqr/highlight.pl
+++ b/clpqr/highlight.pl
@@ -41,7 +41,7 @@
 prolog_colour:goal_colours({Constraints}, imported(File), Colours) :-
 	clpqr_module(Module),
 	module_property(Module, file(File)), !,
-	Colours = goal(imported(File)) - ConstraintColours,
+	Colours = imported(File) - ConstraintColours,
 	constraint_colours(Constraints,	Module, ConstraintColours).
 
 clpqr_module(clpq).


### PR DESCRIPTION
This removes a superfluous `goal/1` layer from the goal class that CLP(Q,R) constraints get when analyzed by `library(prolog_colour)`.  Before this patch, we get calls such as:

```
prolog_colour:colour_item(goal(goal(imported('.../library/clp/clpq.pl')), {...}), ...)
```
With this patch we get:
```
prolog_colour:colour_item(goal(imported('.../library/clp/clpq.pl'), {...}), ...)
```